### PR TITLE
Implemented the pagefactory pattern to improve code resusability and cache the instances of pages

### DIFF
--- a/core/BaseTest.ts
+++ b/core/BaseTest.ts
@@ -1,45 +1,13 @@
 import { test as base } from "@playwright/test";
-import { DataFlowBasePage } from "../pages/dataflowpage/DataFlowBasePage";
-import { CreateTableActionPage } from "../pages/dataflowpage/CreateTableActionPage";
-import { DropTableActionPage } from "../pages/dataflowpage/DropTableActionPage";
+import { PageFactory } from "../core/PageFactory";
 import { LoginPage } from "../pages/LoginPage";
-import { InsertActionPage } from "../pages/dataflowpage/InsertActionPage";
-import { HomePage } from "../pages/HomePage";
 
-export const test = base.extend<{
-    loginPage: LoginPage;
-    dataFlowBasePage: DataFlowBasePage;
-    createTableActionPage: CreateTableActionPage;
-    dropTableActionPage: DropTableActionPage;
-    insertActionPage: InsertActionPage;
-    homePage:HomePage;
-    login: (username: string) => Promise<void>;
-}>({
-    loginPage: async ({ page }, use) => {
-        await use(new LoginPage(page));
-    },
-    dataFlowBasePage: async ({ page }, use) => {
-        await use(new DataFlowBasePage(page));
-    },
-    createTableActionPage: async ({ page }, use) => {
-        await use(new CreateTableActionPage(page));
-    },
-    dropTableActionPage: async ({page}, use)=>{
-        await use(new DropTableActionPage(page));
-    },
-    insertActionPage: async ({page}, use)=>{
-        await use(new InsertActionPage(page));
-    },
-    homePage: async ({page}, use)=>{
-        await use(new HomePage(page));
-    },
-    
-    login: async ({ loginPage }, use) => {
-        await use(async (username: string) => {
-            await loginPage.navigateTo();
-            await loginPage.login(username);
-        });
-    }
+export const test = base.extend<{ pages: PageFactory }>({
+  pages: async ({ page }, use) => {
+    const pageFactory = new PageFactory(page);
+    await pageFactory.getPage(LoginPage).navigateTo(); // Ensure navigation before each test
+    await use(pageFactory);
+  },
 });
 
 export { expect } from "@playwright/test";

--- a/core/PageFactory.ts
+++ b/core/PageFactory.ts
@@ -1,0 +1,17 @@
+import { Page } from "@playwright/test";
+
+export class PageFactory {
+    private pageInstances: Map<string, any> = new Map();
+
+    constructor(private page: Page) {}
+
+    getPage<T>(PageClass: new (page: Page) => T): T {
+        const className = PageClass.name;
+
+        if (!this.pageInstances.has(className)) {
+            this.pageInstances.set(className, new PageClass(this.page));
+        }
+
+        return this.pageInstances.get(className);
+    }
+}

--- a/tests/AppStudio/appBoardLayout.spec.ts
+++ b/tests/AppStudio/appBoardLayout.spec.ts
@@ -5,13 +5,15 @@ import { WaitUtils } from '../../components/WaitUtils';
 import {test} from "../../core/BaseTest"
 import { ActionType } from '../../pages/dataflowpage/DataFlowBasePage';
 import { Page, expect, Locator } from "@playwright/test";
+import { LoginPage } from '../../pages/LoginPage';
 
 
 
 
-test.only('First Test', async({page, login, context}) => {
+test.only('First Test', async({page, pages,context}) => {
+    const loginPage = pages.getPage(LoginPage);
     const waitUtils = new WaitUtils(page);
-    await login("DeployPlanner1");
+    await loginPage.login("DeployPlanner1");
     await page.locator("//div[@data-testid='AppSwitcher_QAId']").click();
     
     const [newPage] = await Promise.all([

--- a/tests/dataFlowTest/dataFlowTest.spec.ts
+++ b/tests/dataFlowTest/dataFlowTest.spec.ts
@@ -3,16 +3,23 @@ import { DropDown } from '../../components/DropDown';
 import { ActionHelper } from '../../ActionHelper/ActionHelper';
 import { WaitUtils } from '../../components/WaitUtils';
 import {test} from "../../core/BaseTest"
-import { ActionType } from '../../pages/dataflowpage/DataFlowBasePage';
+import { ActionType, DataFlowBasePage } from '../../pages/dataflowpage/DataFlowBasePage';
 import { Page, expect, Locator } from "@playwright/test";
+import { LoginPage } from '../../pages/LoginPage';
+import {HomePage} from '../../pages/HomePage';
+import { InsertActionPage } from '../../pages/dataflowpage/InsertActionPage';
 
 
 
 
-test.only('First Test', async({page, login, context,dataFlowBasePage,insertActionPage, homePage}) => {
+test.only('First Test', async({page, pages}) => {
+  const loginPage = pages.getPage(LoginPage);
+  const homePage = pages.getPage(HomePage);
+  const dataFlowBasePage = pages.getPage(DataFlowBasePage);
+  const insertActionPage= pages.getPage(InsertActionPage);
     const waitUtils = new WaitUtils(page);
     const dataFlowName = "Auto_Table_Mapping_Error";
-    await login("RecipeBuilderAdvanced");
+    await loginPage.login("RecipeBuilderAdvanced");
     await homePage.navigateToDataFlow();
 
     await dataFlowBasePage.EnterDataFlowNameAndOpenIt(dataFlowName);

--- a/tests/example.spec.ts
+++ b/tests/example.spec.ts
@@ -3,16 +3,25 @@ import { DropDown } from '../components/DropDown';
 import { ActionHelper } from '../ActionHelper/ActionHelper';
 import { WaitUtils } from '../components/WaitUtils';
 import {test} from "../core/BaseTest"
-import { ActionType } from '../pages/dataflowpage/DataFlowBasePage';
+import { ActionType, DataFlowBasePage } from '../pages/dataflowpage/DataFlowBasePage';
+import { LoginPage } from '../pages/LoginPage';
+import { HomePage } from '../pages/HomePage';
+import { CreateTableActionPage } from '../pages/dataflowpage/CreateTableActionPage';
+import { DropTableActionPage } from '../pages/dataflowpage/DropTableActionPage';
 
 
-test.only('Second Test', async({page,login,dataFlowBasePage,createTableActionPage,dropTableActionPage,homePage}) => {
+test.only('Second Test', async({pages,page}) => {
+  const loginPage = pages.getPage(LoginPage);
+    const homePage = pages.getPage(HomePage);
+    const dataFlowBasePage = pages.getPage(DataFlowBasePage);
+    const createTableActionPage = pages.getPage(CreateTableActionPage);
+    const dropTableActionPage = pages.getPage(DropTableActionPage);
   // const context = await browser.newContext();
   // const page = await context.newPage();
   var connectionName ="conn";
   const dataFlowName="Insertdata";
   const waitUtils = new WaitUtils(page);
-  await login("rameshuser2");
+  await loginPage.login("rameshuser2");
   
   await homePage.navigateToDataFlow();
 


### PR DESCRIPTION
### How the PageFactory Works?

** Storing Page Instances in a Map**

`private pageInstances: Map<string, any> = new Map();`

- pageInstances is a Map that stores page names as keys and their corresponding instances as values.
- It prevents the creation of multiple instances of the same page class, ensuring that we reuse objects efficiently.

![Flow](https://github.com/user-attachments/assets/a5b85ecf-736c-4985-93bc-da8fecfae7ad)







